### PR TITLE
엔터티의 constant에 정적 팩토리 메서드 추가

### DIFF
--- a/module/common/src/main/java/co/oneplat/teamkeeper/common/exception/Business.java
+++ b/module/common/src/main/java/co/oneplat/teamkeeper/common/exception/Business.java
@@ -16,6 +16,11 @@
 
 package co.oneplat.teamkeeper.common.exception;
 
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import jakarta.annotation.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonFormat;
 
 import lombok.Getter;
@@ -51,5 +56,9 @@ public enum Business {
     private final Code domain;
 
     private final String errorMessage;
+
+    public static Optional<Business> of(@Nullable Code code) {
+        return Stream.of(values()).filter(it -> it.code.equals(code)).findFirst();
+    }
 
 }

--- a/module/entity/src/main/java/co/oneplat/teamkeeper/jpa/entity/system/constant/Permission.java
+++ b/module/entity/src/main/java/co/oneplat/teamkeeper/jpa/entity/system/constant/Permission.java
@@ -16,6 +16,9 @@
 
 package co.oneplat.teamkeeper.jpa.entity.system.constant;
 
+import java.util.Optional;
+import java.util.stream.Stream;
+
 import org.springframework.http.HttpMethod;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -56,5 +59,9 @@ public enum Permission {
     private final String name;
 
     private final HttpMethod apiMethod;
+
+    public static Optional<Permission> of(Code code) {
+        return Stream.of(values()).filter(it -> it.code.equals(code)).findFirst();
+    }
 
 }

--- a/module/entity/src/main/java/co/oneplat/teamkeeper/jpa/entity/user/constant/EmploymentState.java
+++ b/module/entity/src/main/java/co/oneplat/teamkeeper/jpa/entity/user/constant/EmploymentState.java
@@ -16,6 +16,9 @@
 
 package co.oneplat.teamkeeper.jpa.entity.user.constant;
 
+import java.util.Optional;
+import java.util.stream.Stream;
+
 import com.fasterxml.jackson.annotation.JsonFormat;
 
 import lombok.Getter;
@@ -43,5 +46,9 @@ public enum EmploymentState {
     private final Code code;
 
     private final String name;
+
+    public static Optional<EmploymentState> of(Code code) {
+        return Stream.of(values()).filter(it -> it.code.equals(code)).findFirst();
+    }
 
 }

--- a/module/entity/src/test/groovy/co/oneplat/teamkeeper/jpa/entity/user/constant/EmploymentStateSpec.groovy
+++ b/module/entity/src/test/groovy/co/oneplat/teamkeeper/jpa/entity/user/constant/EmploymentStateSpec.groovy
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package co.oneplat.teamkeeper.common.exception
+package co.oneplat.teamkeeper.jpa.entity.user.constant
 
 import spock.lang.Specification
 
@@ -22,23 +22,22 @@ import com.fasterxml.jackson.databind.json.JsonMapper
 
 import co.oneplat.teamkeeper.common.object.Code
 
-class BusinessSpec extends Specification {
+class EmploymentStateSpec extends Specification {
 
-    def "Validates integrity of all businesses"() {
+    def "Validates integrity of all employment states"() {
         when:
-        def businesses = Business.values()
+        def states = EmploymentState.values()
 
-        then: "Business must be defined at least one"
-        businesses.length > 0
+        then: "Employment state must be defined at least one"
+        states.length > 0
 
-        then: "All businesses have valid properties"
-        businesses.length > 0
-        businesses.every { it.code }
-        businesses.every { it.domain }
-        businesses.every { !it.errorMessage.blank }
+        then: "All employment states have valid properties"
+        states.length > 0
+        states.every { it.code }
+        states.every { !it.name.blank }
 
-        then: "There is no duplicated business"
-        businesses.collect { it.code }.toSet().size() == businesses.size()
+        then: "There is no duplicated employment state"
+        states.collect { it.code }.toSet().size() == states.size()
     }
 
     def "Converts to JSON as object which has its properties"() {
@@ -46,41 +45,42 @@ class BusinessSpec extends Specification {
         def jsonMapper = JsonMapper.builder().build()
 
         when:
-        def json = jsonMapper.writeValueAsString(business)
+        def json = jsonMapper.writeValueAsString(state)
 
         then:
         def expected = """
         {
             "code": #{code},
-            "domain": #{domain},
-            "errorMessage": #{errorMessage}
+            "name": #{name}
         }
         """.replaceAll(~/\s/, '').replaceAll(~/#\{(\w+)}/) { fullMatch, key ->
-            def property = business[key as String]
+            def property = state[key as String]
             property ? jsonMapper.writeValueAsString(property) : fullMatch
         }
         json == expected
 
         where:
-        business << List.of(Business.values())
+        state << List.of(EmploymentState.values())
     }
 
-    def "Returns the business matched by code"() {
+    def "Returns the employment state matched by code"() {
         given:
         def code = new Code(codeValue)
 
         when:
-        def business = Business.of(code).orElse(null)
+        def state = EmploymentState.of(code).orElse(null)
 
         then:
-        business == expected
+        state == expected
 
         where:
-        codeValue                  | expected
-        "parse_code_object"        | null
-        "common_group_code"        | null
-        "parse:code_object"        | Business.PARSE_CODE_OBJECT
-        "create:common_group_code" | Business.CREATE_COMMON_GROUP_CODE
+        codeValue      | expected
+        "leave"        | null
+        "state:active" | null
+        "active"       | EmploymentState.ACTIVE
+        "on_leave"     | EmploymentState.ON_LEAVE
+        "suspended"    | EmploymentState.SUSPENDED
+        "resigned"     | EmploymentState.RESIGNED
     }
 
 }


### PR DESCRIPTION
네이밍을 `from`과 `of` 중에서 고민했습니다. JDK를 레퍼런스로 살펴보니 아래와 같았어요.

## from

```java
LocalDate.from(TemporalAccessor)
```

시간을 표현한다는 큰 틀에서는 같은 성격이나, 구체적인 범위나 기능이 달라서 별도로 정의되어 있는 **다른 클래스를 해당 클래스로 변환**하고 싶을 때

## of

```java
LocalDate.of(int, int, int)
```

해당 클래스를 구성하는 데에 필요한 요소를 받아서, **전달받은 값대로 해당 객체를 생성**하고 싶을 때

## 결론

전달받은 `Code`와 일치하는 객체를 반환하는 게 목적인 메서드라 네이밍을 `of`로 결정했습니다.
